### PR TITLE
Add regression test for issue 4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     sha256: 8edb028efb1e61bcf25c10e1961a3575fee2af18334ed66ececc23151c49d42c
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx or win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# First smoke test: just print Ignition Gazebo version
+ign gazebo --version 
+
 # Run ign-gazebo -s for few seconds
 timeout 2 ign gazebo -s &> ./ign_gazebo_s_out || true
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+# Run ign-gazebo -s for few seconds
+timeout 2 ign gazebo -s &> ./ign_gazebo_s_out || true
+
+# Print output
+cat ./ign_gazebo_s_out
+
+# Fail if [Err] is found
+grep -v -q "[Err]" ./ign_gazebo_s_out


### PR DESCRIPTION
Add a regression test for https://github.com/conda-forge/libignition-gazebo-feedstock/issues/4 . It should fail as https://github.com/conda-forge/libignition-common-feedstock/pull/36 still needs to be merged.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
