### PR TITLE
Fix meta.yaml logic for autotick-bot compatibility

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -86,7 +86,7 @@ jobs:
 
     - script: |
         call activate base
-        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
 {% set component_name = "gazebo" %}
 {% set base_name = "libignition-" + component_name %}
-{% set version = "5.1.0" %}
-{% set major_version = version.split('.')[0] %}
+{% set version = "5_5.1.0" %}
+{% set version_package = version.split('_')[1] %}
+{% set major_version = version.split('_')[0] %}
 {% set name = base_name + major_version %}
 
 package:
@@ -9,11 +10,11 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
+  - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ version }}.tar.gz
     sha256: 74a093b93c6d9e4276ac5139ff5234800a604bff580f7c09bcd008646b8f02c9
 
 build:
-  number: 2
+  number: 3
   skip: true  # [osx]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ version_package }}
 
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ version }}.tar.gz


### PR DESCRIPTION
This PR changes the definition of the `version` variable to match the format used in the tags, i.e. `4_4.1.0`, so that the autotick-bot (that extracts the version information from git tags by stripping all the characters till the first digit) works fine. The version in `4.1.0` format is now contained in the `version_package` variable (see https://github.com/conda-forge/libignition-msgs1-feedstock/issues/50 and https://github.com/conda-forge/libignition-msgs1-feedstock/issues/53 ).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
