### PR TITLE
Bump version to v6.0.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2019
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-libignition--gazebo5-green.svg)](https://anaconda.org/conda-forge/libignition-gazebo5) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libignition-gazebo5.svg)](https://anaconda.org/conda-forge/libignition-gazebo5) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libignition-gazebo5.svg)](https://anaconda.org/conda-forge/libignition-gazebo5) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libignition-gazebo5.svg)](https://anaconda.org/conda-forge/libignition-gazebo5) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libignition--gazebo6-green.svg)](https://anaconda.org/conda-forge/libignition-gazebo6) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libignition-gazebo6.svg)](https://anaconda.org/conda-forge/libignition-gazebo6) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libignition-gazebo6.svg)](https://anaconda.org/conda-forge/libignition-gazebo6) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libignition-gazebo6.svg)](https://anaconda.org/conda-forge/libignition-gazebo6) |
 
 Installing libignition-gazebo
 =============================
@@ -65,16 +65,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `libignition-gazebo5` can be installed with:
+Once the `conda-forge` channel has been enabled, `libignition-gazebo6` can be installed with:
 
 ```
-conda install libignition-gazebo5
+conda install libignition-gazebo6
 ```
 
-It is possible to list all of the versions of `libignition-gazebo5` available on your platform with:
+It is possible to list all of the versions of `libignition-gazebo6` available on your platform with:
 
 ```
-conda search libignition-gazebo5 --channel conda-forge
+conda search libignition-gazebo6 --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ package:
 
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ version }}.tar.gz
-    sha256: 74a093b93c6d9e4276ac5139ff5234800a604bff580f7c09bcd008646b8f02c9
+    sha256: 09456d491e715604daa36db0f30aa9fa7d96fc54f9b8b8c3f6d2a5aed377b9ce
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set component_name = "gazebo" %}
 {% set base_name = "libignition-" + component_name %}
-{% set version = "5_5.1.0" %}
+{% set version = "6_6.0.0" %}
 {% set version_package = version.split('_')[1] %}
 {% set major_version = version.split('_')[0] %}
 {% set name = base_name + major_version %}
@@ -14,7 +14,7 @@ source:
     sha256: 74a093b93c6d9e4276ac5139ff5234800a604bff580f7c09bcd008646b8f02c9
 
 build:
-  number: 4
+  number: 0
   skip: true  # [osx]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
@@ -35,16 +35,16 @@ requirements:
     - {{ cdt('libxext') }}     # [linux]
   host:
     - libignition-cmake2
-    - libsdformat11
+    - libsdformat12
     - libignition-plugin1
-    - libignition-transport10
-    - libignition-msgs7
+    - libignition-transport11
+    - libignition-msgs8
     - libignition-common4
-    - libignition-fuel-tools6
-    - libignition-gui5
-    - libignition-physics4
-    - libignition-sensors5
-    - libignition-rendering5
+    - libignition-fuel-tools7
+    - libignition-gui6
+    - libignition-physics5
+    - libignition-sensors6
+    - libignition-rendering6
     - libignition-math6
     - libignition-tools1
     - libprotobuf


### PR DESCRIPTION
This was done manually due to https://github.com/conda-forge/libignition-gazebo-feedstock/issues/24 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

