### PR TITLE
Remove v4 from abi migration as it is not supported anymore

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,4 @@
 conda_forge_output_validation: true
-bot:
-  abi_migration_branches: [v4]
 azure:
   settings_win:
       pool:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - use_ogre_as_default.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

See https://github.com/ignition-tooling/release-tools/issues/600 and https://github.com/ignitionrobotics/docs/blob/1ebf12f8f98e41b9174f158679051fb97b10070a/tools/versions.md . As I am not really sure how `abi_migration_branches` works, I will also build the bump number.