### PR TITLE
Enable installation of ign gazebo command also on Windows

### DIFF
--- a/recipe/enable_win_ign.patch
+++ b/recipe/enable_win_ign.patch
@@ -1,0 +1,23 @@
+From bfbff0e0163c37fe825d73c4cd0dd470bce1cdb4 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio.traversaro@iit.it>
+Date: Sun, 3 Jul 2022 19:43:31 +0200
+Subject: [PATCH] Install ignition-tools files also on Windows
+
+Signed-off-by: Silvio <silvio@traversaro.it>
+---
+ src/CMakeLists.txt | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index ff178007c..fd606033a 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -224,7 +224,4 @@ foreach(CMD_TEST
+ 
+ endforeach()
+ 
+-if(NOT WIN32)
+-  add_subdirectory(cmd)
+-endif()
+-
++add_subdirectory(cmd)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,11 @@ package:
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ version }}.tar.gz
     sha256: f5538848cd89711912853ab99faa0c46ee6a4b47c17a8aa06c9814a879d4c8b8
+    patches:
+      - enable_win_ign.patch
 
 build:
-  number: 6
+  number: 7
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
At the moment `ign gazebo` on Windows fails with error:
~~~
(igngaz) C:\Users\STraversaro>ign gazebo --verbose
The 'ign' command provides a command line interface to the ignition tools.

  ign <command> [options]

List of available commands:

  help:          Print this help text.
  fuel:          Manage simulation resources.
  gui:           Launch graphical interfaces.
  msg:           Print information about messages.
  plugin:        Print information about plugins.
  sdf:           Utilities for SDF files.
  topic:         Print information about topics.
  service:       Print information about services.

Options:

  --force-version <VERSION>  Use a specific library version.
  --versions                 Show the available versions.
  --commands                 Show the available commands.
Use 'ign help <command>' to print help for a command.
~~~

This PR enables the installation of `ign gazebo` command on Windows.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
